### PR TITLE
Update versions of Actions dependencies

### DIFF
--- a/.github/workflows/docker-ecr.yml
+++ b/.github/workflows/docker-ecr.yml
@@ -41,7 +41,7 @@ jobs:
     outputs:
       tag_sha: ${{ steps.this.outputs.tag_sha }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - id: this
         uses: cardstack/gh-actions/docker-ecr@main
         with:

--- a/.github/workflows/waypoint-build.yml
+++ b/.github/workflows/waypoint-build.yml
@@ -34,12 +34,12 @@ jobs:
       group: waypoint-build-${{ inputs.app }}-${{ inputs.environment }}-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: ${{ ! inputs.restore-mtime }}
 
       # for certain packages that requires timestamp during their build step
       # https://github.com/cardstack/boxel/pull/276
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: ${{ inputs.restore-mtime }}
         with:
           fetch-depth: 0

--- a/.github/workflows/waypoint-deploy.yml
+++ b/.github/workflows/waypoint-deploy.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     concurrency: waypoint-deploy-${{ inputs.app }}-${{ inputs.environment }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Init
         if: ${{ inputs.init }}

--- a/setup-pnpm-volta/action.yml
+++ b/setup-pnpm-volta/action.yml
@@ -17,6 +17,6 @@ runs:
       run: |
         echo "PNPM_VERSION=${{ fromJson(steps.package-json.outputs.package-json).volta.pnpm }}" >> $GITHUB_ENV
 
-    - uses: pnpm/action-setup@v2
+    - uses: pnpm/action-setup@v3
       with:
         version: ${{ env.PNPM_VERSION }}


### PR DESCRIPTION
This is meant to address deprecation warnings like those seen [here under “Annotations”](https://github.com/cardstack/boxel/actions/runs/8913219034) the [spring deadline](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/) is imminent. The actions here are consumed in `cardstack/boxel`, but some of these will need to be updated there as well.