### PR TITLE
Update Actions dependencies to use Node 24

### DIFF
--- a/.github/workflows/docker-ecr.yml
+++ b/.github/workflows/docker-ecr.yml
@@ -41,7 +41,7 @@ jobs:
     outputs:
       tag_sha: ${{ steps.this.outputs.tag_sha }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - id: this
         uses: cardstack/gh-actions/docker-ecr@main
         with:

--- a/.github/workflows/ecs-deploy.yml
+++ b/.github/workflows/ecs-deploy.yml
@@ -50,7 +50,7 @@ jobs:
           fi
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           aws-region: us-east-1

--- a/.github/workflows/ecs-force-new-deployment.yml
+++ b/.github/workflows/ecs-force-new-deployment.yml
@@ -40,7 +40,7 @@ jobs:
           fi
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           aws-region: us-east-1

--- a/.github/workflows/waypoint-build.yml
+++ b/.github/workflows/waypoint-build.yml
@@ -70,7 +70,7 @@ jobs:
           fi
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           aws-region: us-east-1

--- a/.github/workflows/waypoint-build.yml
+++ b/.github/workflows/waypoint-build.yml
@@ -34,12 +34,12 @@ jobs:
       group: waypoint-build-${{ inputs.app }}-${{ inputs.environment }}-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         if: ${{ ! inputs.restore-mtime }}
 
       # for certain packages that requires timestamp during their build step
       # https://github.com/cardstack/boxel/pull/276
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         if: ${{ inputs.restore-mtime }}
         with:
           fetch-depth: 0

--- a/.github/workflows/waypoint-deploy.yml
+++ b/.github/workflows/waypoint-deploy.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     concurrency: waypoint-deploy-${{ inputs.app }}-${{ inputs.environment }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Init
         if: ${{ inputs.init }}

--- a/.github/workflows/waypoint-deploy.yml
+++ b/.github/workflows/waypoint-deploy.yml
@@ -72,7 +72,7 @@ jobs:
           fi
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           aws-region: us-east-1

--- a/docker-ecr/action.yml
+++ b/docker-ecr/action.yml
@@ -47,7 +47,7 @@ runs:
         fi
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
       with:
         role-to-assume: ${{ env.AWS_ROLE_ARN }}
         aws-region: us-east-1

--- a/docker-ecr/action.yml
+++ b/docker-ecr/action.yml
@@ -32,7 +32,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: docker/setup-buildx-action@v3
+    - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
     - name: Set up env
       shell: bash
@@ -64,7 +64,7 @@ runs:
         echo "tag_latest=${TAG_PREFIX}:latest" >> $GITHUB_OUTPUT
 
     - name: Build and push
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
       with:
         context: ${{ inputs.context }}
         file: ${{ inputs.dockerfile }}


### PR DESCRIPTION
This should silence deprecation warnings as seen [here](https://github.com/cardstack/boxel/actions/runs/25667483667):

<img width="3362" height="2300" alt="CleanShot 2026-05-11 at 06 54 43@2x" src="https://github.com/user-attachments/assets/eeef102c-8432-44e9-b729-8b4bc5718ee0" />
