### PR TITLE
Change caching to use ECR backend instead of GHA

### DIFF
--- a/docker-ecr/action.yml
+++ b/docker-ecr/action.yml
@@ -53,7 +53,7 @@ runs:
         aws-region: us-east-1
 
     - id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v2
+      uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2.1.5
 
     - id: tags
       shell: bash
@@ -62,6 +62,7 @@ runs:
         echo "tag_sha=${TAG_PREFIX}:${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
         echo "tag_env=${TAG_PREFIX}:${{ inputs.environment }}" >> $GITHUB_OUTPUT
         echo "tag_latest=${TAG_PREFIX}:latest" >> $GITHUB_OUTPUT
+        echo "tag_buildcache=${TAG_PREFIX}:buildcache" >> $GITHUB_OUTPUT
 
     - name: Build and push
       uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
@@ -69,8 +70,15 @@ runs:
         context: ${{ inputs.context }}
         file: ${{ inputs.dockerfile }}
         push: true
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+        # Cache layers in an ECR `:buildcache` tag rather than the GHA cache
+        # backend: ECR pulls in-region are far faster for large pnpm-fetch
+        # layers, where the GHA backend transfers too slowly to be a net win.
+        # `image-manifest=true,oci-mediatypes=true` is required — ECR rejects
+        # the default cache manifest format buildx uses for other registries.
+        # `ignore-error=true` keeps a build green if the cache export is denied
+        # (e.g. a role lacking `ecr:PutImage`) or ECR has a transient hiccup.
+        cache-from: type=registry,ref=${{ steps.tags.outputs.tag_buildcache }}
+        cache-to: type=registry,ref=${{ steps.tags.outputs.tag_buildcache }},mode=max,image-manifest=true,oci-mediatypes=true,ignore-error=true
         platforms: ${{ inputs.platforms }}
         build-args: ${{ inputs.build-args }}
         tags: |


### PR DESCRIPTION
This upstreams the caching changes in cardstack/boxel#4831, which have been working in practice since that was merged.

I’ll open a corresponding PR in the monorepo to remove the temporary caching there.

It also updates `aws-actions/amazon-ecr-login`, which had Node 20 deprecation warnings.